### PR TITLE
Sk/editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf # Unix-style newlines
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.env.template
+++ b/.env.template
@@ -51,3 +51,5 @@ IIIF_HOST_URL=
 
 # Set this if using a Docker proxy container
 # RAILS_SERVER_HOSTNAME=annotations.local
+
+USE_JWT_AUTH=Y

--- a/app/controllers/annotations_controller.rb
+++ b/app/controllers/annotations_controller.rb
@@ -707,10 +707,14 @@ end
       parsed_tags << tag
     end
     parsed_tags
-  end 
+  end
 
   def check_anno_auth(request, annotation)
-    AnnoAuthValidator.authorize(request.headers['Authorization'], getTargetingAnnosCanvas(annotation))
+    if Rails.application.config.use_jwt_auth
+      AnnoAuthValidator.authorize(request.headers['Authorization'], getTargetingAnnosCanvas(annotation))
+    else
+      true
+    end
   end
 
   def render_forbidden(message)

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,14 +31,12 @@ module MiradorAnnotationsServer
         'Access-Control-Allow-Methods' => 'POST, PUT, DELETE, GET, OPTIONS',
         'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Accept, Authorization, tgtoken, tgToken, bearer-token',
         'Content-Type' => 'application/json'
-
-    #config.action_dispatch.default_headers.merge!('Content-Type' => 'application/json')
-
     }
 
     config.autoload_paths += Dir["#{config.root}/app/models/", "#{config.root}/lib/**/"]
 
     config.iiif_collections_host = ENV['IIIF_COLLECTIONS_HOST']
     config.s3_download_prefix = ENV['S3_PUBLIC_DOWNLOAD_PREFIX']
+    config.use_jwt_auth = ENV['USE_JWT_AUTH'] == 'Y'
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,8 @@ ENV['RAILS_ENV'] = 'test'
 # use for there expectations, etc.
 ENV['IIIF_HOST_URL'] = 'localhost'
 
+ENV['USE_JWT_AUTH'] = 'Y'
+
 require 'spec_helper'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'


### PR DESCRIPTION
Adding .editorconfig file -- see http://editorconfig.org

It makes easy to share certain editing rules by enabling EditorConfig in settings or installing an EditorConfig for any supported editors.
